### PR TITLE
feat: add jsx api and modern chatbot demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.0](https://github.com/ahmadawais/terminui/compare/0.2.0...0.3.0) (2026-03-02)
+
+### Features
+
+* add React-like JSX runtime and JSX component API for terminal UI composition
+* add new JSX examples: `jsx-hello`, `jsx-dashboard`, and interactive `jsx-chatbot`
+* improve `jsx-chatbot` with alternate-screen app loop, diff-based rendering, simple modern CLI layout, and conversation scrolling via `↑`/`↓`
+
+### Documentation
+
+* document JSX starter/troubleshooting and chatbot controls in README
+
 ## [0.2.0](https://github.com/ahmadawais/terminui/compare/0.1.0...0.2.0) (2026-03-01)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -73,6 +73,129 @@ Output:
 └──────────────────────────────────────────────────────┘
 ```
 
+## JSX API (React-like)
+
+You can keep the same terminal performance model and write UIs in a JSX style.
+
+`terminui` does not use a virtual DOM reconciler here; JSX is translated into the same widget render calls (`frameRenderWidget`, `frameRenderStatefulWidget`) and still uses the existing double-buffered diff renderer.
+
+```tsx
+/** @jsxImportSource terminui */
+import { createTestBackendState, createTestBackend, createTerminal } from 'terminui';
+import { terminalDrawJsx, Column, Row, Panel, Label, List, Gauge } from 'terminui/jsx';
+import { lengthConstraint, fillConstraint } from 'terminui';
+
+const state = createTestBackendState(60, 12);
+const terminal = createTerminal(createTestBackend(state));
+
+terminalDrawJsx(
+  terminal,
+  <Column constraints={[lengthConstraint(3), fillConstraint(1)]}>
+    <Panel title="Header" p={1}>
+      <Label text="JSX-powered terminal UI" align="center" bold />
+    </Panel>
+    <Row constraints={[fillConstraint(1), fillConstraint(1)]} gap={1}>
+      <Panel title="Menu">
+        <List items={['Overview', 'Metrics', 'Logs']} />
+      </Panel>
+      <Panel title="Load">
+        <Gauge percent={42} />
+      </Panel>
+    </Row>
+  </Column>,
+);
+```
+
+Available JSX components include `VStack`, `HStack`, `Box`, `Text`, `List`, `Table`, `Gauge`, `LineGauge`, `Tabs`, `Sparkline`, `BarChart`, `Scrollbar`, `Clear`, and `Cursor`.
+
+React-like aliases are also available:
+
+- `Row` = `HStack`
+- `Column` = `VStack`
+- `Panel` = `Box` with border enabled by default
+- `Label` = `Text`
+
+Common shorthand props:
+
+- `gap` on `Row` / `Column` for spacing
+- `p`, `px`, `py` for panel/widget padding
+- `border` and `title` for block setup
+- `fg`, `bg`, `bold` for style
+- `align` for text alignment
+
+Helper APIs:
+
+- `terminalDrawJsx(terminal, <UI />)`
+- `terminalLoopJsx(terminal, (frame, tick) => <UI />, { maxFrames: 120 })`
+
+### JSX Starter (Copy/Paste)
+
+Minimal `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "terminui"
+  }
+}
+```
+
+Minimal `hello.tsx`:
+
+```tsx
+/** @jsxRuntime automatic */
+/** @jsxImportSource terminui */
+import { createTestBackendState, createTestBackend, createTerminal, testBackendToString } from 'terminui';
+import { terminalDrawJsx, Panel, Label } from 'terminui/jsx';
+import { Color } from 'terminui';
+
+const state = createTestBackendState(40, 6);
+const terminal = createTerminal(createTestBackend(state));
+
+terminalDrawJsx(
+  terminal,
+  <Panel title="Hello JSX" p={1}>
+    <Label text="terminal UI, React-like syntax" fg={Color.Cyan} bold align="center" />
+  </Panel>,
+);
+
+console.log(testBackendToString(state));
+```
+
+### JSX Troubleshooting
+
+If you see a TypeScript error like:
+
+```text
+'X' cannot be used as a JSX component
+```
+
+check the following:
+
+1. Use `.tsx` files for JSX code.
+2. Use automatic JSX runtime with `terminui` as the import source.
+3. Import UI components from `terminui/jsx` (not from `react`).
+4. Make sure you are on a recent `terminui` version with JSX typing fixes.
+
+`tsconfig.json` example:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "terminui"
+  }
+}
+```
+
+Per-file override (optional):
+
+```tsx
+/** @jsxRuntime automatic */
+/** @jsxImportSource terminui */
+```
+
 ## Architecture
 
 terminui follows a functional architecture with zero classes:
@@ -437,6 +560,15 @@ The double-buffered architecture ensures only changed cells are written between 
 Run the included examples:
 
 ```bash
+# Minimal JSX starter
+npx tsx examples/jsx-hello.tsx
+
+# Interactive fake-AI terminal chat demo
+npx tsx examples/jsx-chatbot.tsx
+
+# React-like JSX API demo
+npx tsx examples/jsx-dashboard.tsx
+
 # Dashboard rendered to primary screen
 npx tsx examples/primary-screen.ts
 
@@ -452,6 +584,18 @@ npx tsx examples/weather-dashboard.ts --city "New York"
 # One-shot weather snapshot (non-animated)
 npx tsx examples/weather-dashboard.ts --city "New York" --once
 ```
+
+`examples/jsx-chatbot.tsx` is the production-style reference for interactive terminal UX:
+
+- uses alternate screen and clears scrollback
+- uses `readline` keypress input in raw mode (no prompt spam)
+- uses diff-based cell updates with batched ANSI writes
+- uses a minimal, modern CLI layout (vim/blessed-like)
+- includes interactive controls:
+  - `Enter` send message
+  - `↑` / `↓` scroll conversation
+  - `/clear` reset chat history
+  - `Esc` or `Ctrl+C` quit cleanly
 
 ## Dev
 

--- a/examples/jsx-chatbot.tsx
+++ b/examples/jsx-chatbot.tsx
@@ -1,0 +1,650 @@
+/**
+ * Interactive JSX Chatbot Demo (Fake AI)
+ *
+ * Real TTY demo:
+ * - Alternate screen buffer (no scrollback spam)
+ * - Raw keyboard input
+ * - Diff-based terminal drawing with batched ANSI writes (reduced flicker)
+ *
+ * Run: npx tsx examples/jsx-chatbot.tsx
+ */
+/** @jsxRuntime automatic */
+/** @jsxImportSource ../src */
+import readline from 'node:readline';
+import { stdin as input, stdout as output } from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import type { Cell } from '../src/core/buffer';
+import { charWidth } from '../src/core/buffer';
+import { createSize } from '../src/core/layout';
+import type { Position, Size } from '../src/core/layout';
+import type { Backend } from '../src/core/terminal';
+import { createTerminal, terminalResize } from '../src/core/terminal';
+import type { Color as TerminalColor } from '../src/core/style';
+import { Color, Modifier, indexedColor } from '../src/core/style';
+import { Box, Column, Cursor, Label, Panel, Row, Text, terminalDrawJsx } from '../src/jsx';
+import { fillConstraint, lengthConstraint } from '../src';
+
+interface ChatMessage {
+	readonly role: 'user' | 'assistant';
+	content: string;
+	readonly at: number;
+}
+
+interface AppState {
+	messages: ChatMessage[];
+	input: string;
+	status: string;
+	busy: boolean;
+	startedAt: number;
+	typingStep: number;
+	scrollFromBottom: number;
+	chatViewportLines: number;
+}
+
+const MAX_MESSAGES = 240;
+const THEME = {
+	accent: indexedColor(81),
+	muted: indexedColor(244),
+	success: indexedColor(84),
+	user: indexedColor(111),
+	assistant: indexedColor(222),
+} as const;
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+const colorKey = (color: TerminalColor | undefined): string => {
+	if (color === undefined) {
+		return 'u';
+	}
+	if (color.type === 'indexed') {
+		return `i:${color.index}`;
+	}
+	if (color.type === 'rgb') {
+		return `r:${color.r}:${color.g}:${color.b}`;
+	}
+	return `n:${color.type}`;
+};
+
+const namedColorAnsi = (type: string, bg: boolean): string => {
+	const fgMap: Record<string, number> = {
+		black: 30,
+		red: 31,
+		green: 32,
+		yellow: 33,
+		blue: 34,
+		magenta: 35,
+		cyan: 36,
+		gray: 37,
+		'dark-gray': 90,
+		'light-red': 91,
+		'light-green': 92,
+		'light-yellow': 93,
+		'light-blue': 94,
+		'light-magenta': 95,
+		'light-cyan': 96,
+		white: 97,
+	};
+	const bgMap: Record<string, number> = {
+		black: 40,
+		red: 41,
+		green: 42,
+		yellow: 43,
+		blue: 44,
+		magenta: 45,
+		cyan: 46,
+		gray: 47,
+		'dark-gray': 100,
+		'light-red': 101,
+		'light-green': 102,
+		'light-yellow': 103,
+		'light-blue': 104,
+		'light-magenta': 105,
+		'light-cyan': 106,
+		white: 107,
+	};
+	const code = (bg ? bgMap : fgMap)[type];
+	return code === undefined ? (bg ? '49' : '39') : String(code);
+};
+
+const colorAnsi = (color: TerminalColor | undefined, bg: boolean): string => {
+	if (color === undefined) {
+		return bg ? '49' : '39';
+	}
+	if (color.type === 'reset') {
+		return bg ? '49' : '39';
+	}
+	if (color.type === 'indexed') {
+		return `${bg ? '48' : '38'};5;${color.index}`;
+	}
+	if (color.type === 'rgb') {
+		return `${bg ? '48' : '38'};2;${color.r};${color.g};${color.b}`;
+	}
+	return namedColorAnsi(color.type, bg);
+};
+
+const modifierAnsi = (modifier: number): readonly string[] => {
+	const codes: string[] = [];
+	if (Modifier.contains(modifier, Modifier.BOLD)) codes.push('1');
+	if (Modifier.contains(modifier, Modifier.DIM)) codes.push('2');
+	if (Modifier.contains(modifier, Modifier.ITALIC)) codes.push('3');
+	if (Modifier.contains(modifier, Modifier.UNDERLINED)) codes.push('4');
+	if (Modifier.contains(modifier, Modifier.SLOW_BLINK)) codes.push('5');
+	if (Modifier.contains(modifier, Modifier.RAPID_BLINK)) codes.push('6');
+	if (Modifier.contains(modifier, Modifier.REVERSED)) codes.push('7');
+	if (Modifier.contains(modifier, Modifier.HIDDEN)) codes.push('8');
+	if (Modifier.contains(modifier, Modifier.CROSSED_OUT)) codes.push('9');
+	if (Modifier.contains(modifier, Modifier.DOUBLE_UNDERLINED)) codes.push('21');
+	if (Modifier.contains(modifier, Modifier.OVERLINED)) codes.push('53');
+	return codes;
+};
+
+const moveTo = (x: number, y: number): string => `\u001B[${y + 1};${x + 1}H`;
+
+const styleKey = (cell: Cell): string => `${colorKey(cell.fg)}|${colorKey(cell.bg)}|${cell.modifier}`;
+
+const styleAnsi = (cell: Cell): string => {
+	const codes = [
+		colorAnsi(cell.fg, false),
+		colorAnsi(cell.bg, true),
+		...modifierAnsi(cell.modifier),
+	];
+	return `\u001B[0;${codes.join(';')}m`;
+};
+
+const symbolOutput = (cell: Cell): string => (cell.symbol === '' ? ' ' : cell.symbol);
+
+const createAnsiBackend = (): Backend => {
+	let pending = '';
+	let style = '';
+	let cursor: Position = { x: 0, y: 0 };
+
+	const write = (chunk: string): void => {
+		output.write(chunk);
+	};
+
+	const size = (): Size => ({
+		width: Math.max(70, output.columns ?? 90),
+		height: Math.max(18, (output.rows ?? 28) - 1),
+	});
+
+	return {
+		size,
+		draw: (content): void => {
+			if (content.length === 0) {
+				return;
+			}
+
+			const sorted = [...content].sort((a, b) => (a.y - b.y) || (a.x - b.x));
+			for (const entry of sorted) {
+				if (cursor.y !== entry.y || cursor.x !== entry.x) {
+					pending += moveTo(entry.x, entry.y);
+					cursor = { x: entry.x, y: entry.y };
+				}
+
+				const key = styleKey(entry.cell);
+				if (key !== style) {
+					pending += styleAnsi(entry.cell);
+					style = key;
+				}
+
+				const symbol = symbolOutput(entry.cell);
+				pending += symbol;
+				cursor = {
+					x: cursor.x + Math.max(1, charWidth(symbol.codePointAt(0) ?? 0)),
+					y: cursor.y,
+				};
+			}
+		},
+		flush: (): void => {
+			if (pending.length === 0) {
+				return;
+			}
+			write(pending);
+			pending = '';
+		},
+		hideCursor: (): void => {
+			write('\u001B[?25l');
+		},
+		showCursor: (): void => {
+			write('\u001B[?25h');
+		},
+		getCursorPosition: (): Position => cursor,
+		setCursorPosition: (pos: Position): void => {
+			cursor = pos;
+			write(moveTo(pos.x, pos.y));
+		},
+		clear: (): void => {
+			write('\u001B[2J\u001B[H');
+			style = '';
+			cursor = { x: 0, y: 0 };
+		},
+	};
+};
+
+const fakeAiResponse = (userInput: string, turn: number): string => {
+	const text = userInput.trim();
+	const lower = text.toLowerCase();
+
+	if (lower.includes('hello') || lower.includes('hi')) {
+		return 'Hello. I am running in mock mode, but the interaction model is real and event-driven.';
+	}
+	if (lower.includes('regex')) {
+		return 'Try: ^[a-zA-Z0-9_-]{3,16}$ for a username. Share exact constraints and I can refine it.';
+	}
+	if (lower.includes('plan') || lower.includes('schedule')) {
+		return 'Plan template: define top 3 outcomes, estimate effort, timebox focus blocks, and keep 20% buffer.';
+	}
+	if (lower.includes('typescript') || lower.includes('ts')) {
+		return 'TypeScript practice: strict interfaces at boundaries, narrow unknowns early, avoid implicit any.';
+	}
+	if (lower.includes('performance')) {
+		return 'Performance strategy: measure first, reduce redraw scope, batch updates, and avoid unnecessary allocations.';
+	}
+	if (lower.endsWith('?')) {
+		return `Great question. Mock answer #${turn}: start with the smallest useful slice, validate it, then iterate.`;
+	}
+
+	const canned = [
+		'This is a fake AI response, but the terminal UX loop here is close to a production interaction pattern.',
+		'If wired to a real model, this panel would stream token chunks while preserving stable layout and cursor.',
+		'Try prompting me with: "design a CLI command API" or "explain debounce vs throttle".',
+	];
+	return canned[turn % canned.length] ?? 'Mock response.';
+};
+
+const streamTokens = async (
+	target: ChatMessage,
+	reply: string,
+	onToken: () => void,
+): Promise<void> => {
+	const parts = reply.split(/(\s+)/).filter((s) => s.length > 0);
+	for (const part of parts) {
+		target.content += part;
+		onToken();
+		await sleep(20 + Math.floor(Math.random() * 35));
+	}
+};
+
+const normalizeInput = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const trimMessages = (messages: ChatMessage[]): void => {
+	if (messages.length <= MAX_MESSAGES) {
+		return;
+	}
+	messages.splice(0, messages.length - MAX_MESSAGES);
+};
+
+const formatTime = (at: number): string => {
+	const date = new Date(at);
+	const hh = String(date.getHours()).padStart(2, '0');
+	const mm = String(date.getMinutes()).padStart(2, '0');
+	const ss = String(date.getSeconds()).padStart(2, '0');
+	return `${hh}:${mm}:${ss}`;
+};
+
+const indentLines = (text: string, prefix: string): string =>
+	text
+		.split('\n')
+		.map((line) => `${prefix}${line}`)
+		.join('\n');
+
+const stringCellWidth = (text: string): number => {
+	let width = 0;
+	for (const ch of text) {
+		width += Math.max(1, charWidth(ch.codePointAt(0) ?? 0));
+	}
+	return width;
+};
+
+const buildTranscript = (messages: readonly ChatMessage[]): string =>
+	messages
+		.map((m, i) => {
+			const role = m.role === 'user' ? 'you' : 'assistant';
+			return `${role} · ${String(i + 1).padStart(2, '0')} · ${formatTime(m.at)}\n${indentLines(m.content, '  ')}`;
+		})
+		.join('\n\n');
+
+const uptimeText = (startedAt: number): string => {
+	const sec = Math.floor((Date.now() - startedAt) / 1000);
+	const mm = String(Math.floor(sec / 60)).padStart(2, '0');
+	const ss = String(sec % 60).padStart(2, '0');
+	return `${mm}:${ss}`;
+};
+
+const run = async (): Promise<void> => {
+	if (!input.isTTY || !output.isTTY) {
+		output.write('This demo requires an interactive TTY.\n');
+		process.exitCode = 1;
+		return;
+	}
+
+	const backend = createAnsiBackend();
+	const terminal = createTerminal(backend);
+	const app: AppState = {
+		messages: [
+			{
+				role: 'assistant',
+				content:
+					'Welcome. This demo is fake-AI content with a real-time terminal UI loop. Type /exit to quit.',
+				at: Date.now(),
+			},
+		],
+		input: '',
+		status: 'Idle',
+		busy: false,
+		startedAt: Date.now(),
+		typingStep: 0,
+		scrollFromBottom: 0,
+		chatViewportLines: 1,
+	};
+
+	let shuttingDown = false;
+	let renderTimer: NodeJS.Timeout | undefined;
+	let heartbeatTimer: NodeJS.Timeout | undefined;
+
+	const safeCleanup = (): void => {
+		if (shuttingDown) {
+			return;
+		}
+		shuttingDown = true;
+
+		if (renderTimer !== undefined) {
+			clearTimeout(renderTimer);
+			renderTimer = undefined;
+		}
+		if (heartbeatTimer !== undefined) {
+			clearInterval(heartbeatTimer);
+			heartbeatTimer = undefined;
+		}
+
+		output.off('resize', onResize);
+		input.off('keypress', onKeypress);
+
+		try {
+			input.setRawMode(false);
+		} catch {
+			// ignore
+		}
+
+		output.write('\u001B[0m\u001B[?25h');
+		output.write('\u001B[?1049l');
+		output.write('\u001B[2J\u001B[3J\u001B[H');
+	};
+
+	const renderNow = (): void => {
+		if (shuttingDown) {
+			return;
+		}
+
+		const frameArea = terminal.viewportArea;
+		const sideWidth = Math.min(32, Math.max(24, Math.floor(frameArea.width * 0.28)));
+		const bodyHeight = Math.max(1, frameArea.height - 11);
+		const transcript = buildTranscript(app.messages);
+		const chatInnerHeight = Math.max(1, bodyHeight - 2);
+		app.chatViewportLines = chatInnerHeight;
+		const totalLines = transcript.split('\n').length;
+		const maxScrollFromBottom = Math.max(0, totalLines - chatInnerHeight);
+		if (app.scrollFromBottom > maxScrollFromBottom) {
+			app.scrollFromBottom = maxScrollFromBottom;
+		}
+		const scrollFromBottom = app.scrollFromBottom;
+		const scrollY = Math.max(0, maxScrollFromBottom - scrollFromBottom);
+		const prompt = '> ';
+
+		terminalDrawJsx(terminal, (frame) => {
+			const inputMax = Math.max(1, frame.area.width - 8 - prompt.length);
+			const visibleInput = app.input.slice(-inputMax);
+			const cursorX = clamp(prompt.length + stringCellWidth(visibleInput), 0, prompt.length + inputMax);
+			const statusTone = app.busy ? Color.LightYellow : Color.LightGreen;
+			const statusText = app.busy ? 'streaming' : 'ready';
+			const modeText = app.busy
+				? 'assistant typing...'
+				: scrollFromBottom > 0
+					? `scroll lock +${scrollFromBottom}`
+					: 'normal mode';
+			const sidebarText =
+				'buffers\n' +
+				'  chat/main         active\n' +
+				'  notes/today       idle\n' +
+				'  draft/review      idle\n\n' +
+				'workspace\n' +
+				'  terminui/examples\n\n' +
+				'engine\n' +
+				'  mock local stream';
+			const hotkeysText =
+				'keys\n' +
+				'  Enter   send\n' +
+				'  Esc     quit\n' +
+				'  ↑/↓     scroll chat\n' +
+				'  /clear  wipe chat';
+
+			return (
+					<Column constraints={[lengthConstraint(3), fillConstraint(1), lengthConstraint(7)]} gap={1}>
+					<Panel title="terminui chat" p={1} fg={THEME.accent}>
+						<Row constraints={[lengthConstraint(10), fillConstraint(1), lengthConstraint(24)]}>
+							<Label text=" NORMAL " fg={THEME.success} bold />
+							<Label text={modeText} align="center" fg={THEME.muted} />
+							<Label text={`status ${statusText} · uptime ${uptimeText(app.startedAt)}`} align="right" fg={statusTone} />
+						</Row>
+					</Panel>
+
+					<Row constraints={[lengthConstraint(sideWidth), fillConstraint(1)]} gap={1}>
+						<Column constraints={[fillConstraint(1), lengthConstraint(7)]} gap={1}>
+							<Panel title="workspace" p={1} fg={Color.LightCyan}>
+								<Text text={sidebarText} wrap={{ trim: true }} />
+							</Panel>
+							<Panel title="help" p={1} fg={Color.LightBlue}>
+								<Text text={hotkeysText} wrap={{ trim: true }} />
+							</Panel>
+						</Column>
+
+						<Panel
+							title={`conversation · ${app.messages.length} messages${scrollFromBottom > 0 ? ` · +${scrollFromBottom}` : ''}`}
+							p={1}
+							fg={THEME.accent}
+						>
+							<Text text={transcript} wrap={{ trim: true }} scroll={[scrollY, 0]} />
+						</Panel>
+					</Row>
+
+					<Panel title="command" p={1} fg={THEME.accent}>
+						<Column constraints={[lengthConstraint(1), fillConstraint(1)]}>
+							<Row constraints={[fillConstraint(1), lengthConstraint(20)]}>
+								<Label text="Enter send · ↑/↓ scroll · Esc quit" fg={THEME.muted} />
+								<Label text={`status ${app.status}`} align="right" fg={statusTone} bold />
+							</Row>
+							<Box>
+								<Text text={`${prompt}${visibleInput}`} fg={Color.White} />
+								<Cursor x={cursorX} y={0} />
+							</Box>
+						</Column>
+					</Panel>
+				</Column>
+			);
+		});
+	};
+
+	const requestRender = (): void => {
+		if (shuttingDown || renderTimer !== undefined) {
+			return;
+		}
+		renderTimer = setTimeout(() => {
+			renderTimer = undefined;
+			renderNow();
+		}, 16);
+	};
+
+	const onResize = (): void => {
+		terminalResize(terminal, createSize(backend.size().width, backend.size().height));
+		renderNow();
+	};
+
+	const maxScrollFromBottom = (): number => {
+		const lines = buildTranscript(app.messages).split('\n').length;
+		return Math.max(0, lines - Math.max(1, app.chatViewportLines));
+	};
+
+	const scrollConversation = (delta: number): void => {
+		const next = clamp(app.scrollFromBottom + delta, 0, maxScrollFromBottom());
+		if (next !== app.scrollFromBottom) {
+			app.scrollFromBottom = next;
+			requestRender();
+		}
+	};
+
+	const submit = async (): Promise<void> => {
+		const message = normalizeInput(app.input);
+		app.input = '';
+
+		if (message.length === 0) {
+			requestRender();
+			return;
+		}
+
+		if (message === '/exit' || message === 'exit' || message === 'quit') {
+			safeCleanup();
+			process.exit(0);
+		}
+
+		if (message === '/clear') {
+			app.messages = [{
+				role: 'assistant',
+				content: 'History cleared. Continue chatting.',
+				at: Date.now(),
+			}];
+			app.status = 'Idle';
+			app.scrollFromBottom = 0;
+			requestRender();
+			return;
+		}
+
+		if (app.busy) {
+			return;
+		}
+
+		app.scrollFromBottom = 0;
+		app.messages.push({ role: 'user', content: message, at: Date.now() });
+		trimMessages(app.messages);
+		app.busy = true;
+		app.status = 'Thinking...';
+		requestRender();
+
+		await sleep(120 + Math.min(600, message.length * 7));
+
+		const reply: ChatMessage = { role: 'assistant', content: '', at: Date.now() };
+		app.messages.push(reply);
+		trimMessages(app.messages);
+		app.status = 'Streaming...';
+		requestRender();
+
+		const full = fakeAiResponse(message, app.messages.length);
+		app.typingStep++;
+		const step = app.typingStep;
+		await streamTokens(reply, full, () => {
+			if (step !== app.typingStep || shuttingDown) {
+				return;
+			}
+			requestRender();
+		});
+
+		app.busy = false;
+		app.status = 'Idle';
+		requestRender();
+	};
+
+	readline.emitKeypressEvents(input);
+	input.setRawMode(true);
+	input.resume();
+
+	const onKeypress = (str: string | undefined, key: readline.Key | undefined): void => {
+		if (shuttingDown) {
+			return;
+		}
+
+		if (key?.ctrl && key.name === 'c') {
+			safeCleanup();
+			process.exit(0);
+			return;
+		}
+		if (key?.name === 'up') {
+			scrollConversation(1);
+			return;
+		}
+		if (key?.name === 'down') {
+			scrollConversation(-1);
+			return;
+		}
+
+		if (key?.name === 'escape') {
+			safeCleanup();
+			process.exit(0);
+			return;
+		}
+
+		if (key?.name === 'return' || key?.name === 'enter' || str === '\r' || str === '\n') {
+			void submit();
+			return;
+		}
+
+		if (key?.name === 'backspace' || str === '\u0008' || str === '\u007f') {
+			if (!app.busy && app.input.length > 0) {
+				app.input = app.input.slice(0, -1);
+				requestRender();
+			}
+			return;
+		}
+
+		if (app.busy || key?.ctrl || key?.meta) {
+			return;
+		}
+
+		let raw = str ?? key?.sequence ?? '';
+		if (raw.length === 0) {
+			if (key?.name === 'space') {
+				raw = ' ';
+			} else if (typeof key?.name === 'string' && key.name.length === 1) {
+				raw = key.shift ? key.name.toUpperCase() : key.name;
+			}
+		}
+
+		const printable = raw.replace(/[\u0000-\u001F\u007F]/g, '');
+		if (printable.length === 0) {
+			return;
+		}
+
+		let changed = false;
+		for (const ch of printable) {
+			const w = charWidth(ch.codePointAt(0) ?? 0);
+			if (w > 0) {
+				app.input += ch;
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			requestRender();
+		}
+	};
+
+	output.write('\u001B[?1049h'); // alternate screen
+	output.write('\u001B[2J\u001B[3J\u001B[H'); // clear screen + scrollback
+	output.write('\u001B[?25l');
+
+	input.on('keypress', onKeypress);
+	output.on('resize', onResize);
+	heartbeatTimer = setInterval(() => requestRender(), 1_000);
+	onResize();
+
+	process.on('exit', () => safeCleanup());
+	process.on('SIGTERM', () => {
+		safeCleanup();
+		process.exit(0);
+	});
+	process.on('SIGINT', () => {
+		safeCleanup();
+		process.exit(0);
+	});
+};
+
+void run();

--- a/examples/jsx-dashboard.tsx
+++ b/examples/jsx-dashboard.tsx
@@ -1,0 +1,66 @@
+/**
+ * JSX Dashboard Demo
+ *
+ * Shows the React-like JSX API for composing terminal UIs.
+ *
+ * Run: npx tsx examples/jsx-dashboard.tsx
+ */
+/** @jsxRuntime automatic */
+/** @jsxImportSource ../src */
+import { createTestBackend, createTestBackendState, testBackendToString } from '../src/backends/test';
+import { fillConstraint, lengthConstraint } from '../src/core/layout';
+import { createTerminal } from '../src/core/terminal';
+import { Color } from '../src/core/style';
+import {
+	Column,
+	Gauge,
+	Label,
+	List,
+	Panel,
+	Row,
+	terminalDrawJsx,
+} from '../src/jsx';
+import { createListState } from '../src/widgets/list';
+
+const WIDTH = 80;
+const HEIGHT = 18;
+
+const state = createTestBackendState(WIDTH, HEIGHT);
+const backend = createTestBackend(state);
+const terminal = createTerminal(backend);
+
+const listState = createListState(1);
+
+terminalDrawJsx(
+	terminal,
+	<Column constraints={[lengthConstraint(3), fillConstraint(1), lengthConstraint(3)]}>
+		<Panel title="terminui JSX" p={1}>
+			<Label
+				text="React-like JSX syntax on top of the same fast diff renderer."
+				align="center"
+				fg={Color.LightCyan}
+				bold
+			/>
+		</Panel>
+
+		<Row constraints={[fillConstraint(1), fillConstraint(1)]} gap={1}>
+			<Panel title="Tasks">
+				<List
+					items={['Fetch data', 'Render widgets', 'Flush diff', 'Await input']}
+					state={listState}
+					highlightSymbol="▶ "
+				/>
+			</Panel>
+			<Panel title="Progress">
+				<Gauge percent={72} />
+			</Panel>
+		</Row>
+
+		<Panel p={1}>
+			<Label text="Run this file with tsx to see the rendered frame output." align="center" />
+		</Panel>
+	</Column>,
+);
+
+console.log(testBackendToString(state));
+console.log('\n--- JSX Dashboard Demo (terminui) ---');

--- a/examples/jsx-hello.tsx
+++ b/examples/jsx-hello.tsx
@@ -1,0 +1,25 @@
+/**
+ * JSX Hello Starter
+ *
+ * Minimal copy-paste starting point for terminui JSX.
+ *
+ * Run: npx tsx examples/jsx-hello.tsx
+ */
+/** @jsxRuntime automatic */
+/** @jsxImportSource ../src */
+import { createTestBackend, createTestBackendState, testBackendToString } from '../src/backends/test';
+import { createTerminal } from '../src/core/terminal';
+import { Color } from '../src/core/style';
+import { Label, Panel, terminalDrawJsx } from '../src/jsx';
+
+const state = createTestBackendState(40, 6);
+const terminal = createTerminal(createTestBackend(state));
+
+terminalDrawJsx(
+	terminal,
+	<Panel title="Hello JSX" p={1}>
+		<Label text="terminal UI, React-like syntax" fg={Color.Cyan} bold align="center" />
+	</Panel>,
+);
+
+console.log(testBackendToString(state));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
+		},
+		"./jsx": {
+			"types": "./dist/jsx.d.ts",
+			"import": "./dist/jsx.js"
+		},
+		"./jsx-runtime": {
+			"types": "./dist/jsx-runtime.d.ts",
+			"import": "./dist/jsx-runtime.js"
 		}
 	},
 	"files": [
@@ -28,6 +36,14 @@
 		"terminal",
 		"ui",
 		"ratatui",
+		"react",
+		"ink",
+		"clack",
+		"blessed",
+		"terminal ui",
+		"text ui",
+		"text user interface",
+		"terminal user interface",
 		"cli"
 	],
 	"license": "Apache-2.0",

--- a/src/__tests__/jsx.test.ts
+++ b/src/__tests__/jsx.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestBackend, createTestBackendState, testBackendToString } from '../backends/test';
+import { fillConstraint, lengthConstraint } from '../core/layout';
+import { createTerminal, terminalDraw } from '../core/terminal';
+import { Color, Modifier } from '../core/style';
+import { jsx, jsxs } from '../jsx-runtime';
+import {
+	Box,
+	Column,
+	Cursor,
+	Fragment,
+	Gauge,
+	HStack,
+	Label,
+	List,
+	Panel,
+	Row,
+	Text,
+	VStack,
+	renderJsx,
+	renderUI,
+	terminalDrawJsx,
+	terminalLoopJsx,
+} from '../jsx';
+import { createListState } from '../widgets/list';
+
+const findCellBySymbol = (
+	state: ReturnType<typeof createTestBackendState>,
+	symbol: string,
+) => {
+	for (const row of state.buffer) {
+		for (const cell of row) {
+			if (cell.symbol === symbol) {
+				return cell;
+			}
+		}
+	}
+	return undefined;
+};
+
+describe('jsx renderer', () => {
+	it('renders nested layout and widgets', () => {
+		const state = createTestBackendState(40, 10);
+		const terminal = createTerminal(createTestBackend(state));
+		const listState = createListState(1);
+
+		terminalDraw(terminal, (frame) => {
+			renderJsx(
+				frame,
+				jsxs(VStack, {
+					constraints: [lengthConstraint(3), fillConstraint(1)],
+					children: [
+						jsx(Box, {
+							bordered: true,
+							title: 'Header',
+							children: jsx(Text, { text: 'JSX UI' }),
+						}),
+						jsxs(HStack, {
+							constraints: [fillConstraint(1), fillConstraint(1)],
+							spacing: 1,
+							children: [
+								jsx(Box, {
+									bordered: true,
+									title: 'Menu',
+									children: jsx(List, {
+										items: ['Overview', 'Metrics', 'Logs'],
+										state: listState,
+										highlightSymbol: '> ',
+									}),
+								}),
+								jsx(Box, {
+									bordered: true,
+									title: 'Load',
+									children: jsx(Gauge, { percent: 42 }),
+								}),
+							],
+						}),
+					],
+				}),
+			);
+		});
+
+		const output = testBackendToString(state);
+		expect(output).toContain('Header');
+		expect(output).toContain('JSX UI');
+		expect(output).toContain('Menu');
+		expect(output).toContain('Load');
+	});
+
+	it('supports function components', () => {
+		const state = createTestBackendState(24, 5);
+		const terminal = createTerminal(createTestBackend(state));
+
+		const Greeting = ({ name }: { readonly name: string }) =>
+			jsx(Box, {
+				bordered: true,
+				title: 'Greeting',
+				children: jsx(Text, { text: `Hi ${name}` }),
+			});
+
+		terminalDraw(terminal, (frame) => {
+			renderUI(frame, jsx(Greeting, { name: 'Ada' }));
+		});
+
+		const output = testBackendToString(state);
+		expect(output).toContain('Greeting');
+		expect(output).toContain('Hi Ada');
+	});
+
+	it('supports fragment and cursor positioning', () => {
+		const state = createTestBackendState(12, 4);
+		const terminal = createTerminal(createTestBackend(state));
+
+		terminalDraw(terminal, (frame) => {
+			renderJsx(
+				frame,
+				jsxs(Fragment, {
+					children: [
+						jsx(Text, { text: 'cursor demo' }),
+						jsx(Cursor, { x: 2, y: 1 }),
+					],
+				}),
+			);
+		});
+
+		expect(state.cursorVisible).toBe(true);
+		expect(state.cursorPosition).toEqual({ x: 2, y: 1 });
+		expect(testBackendToString(state)).toContain('cursor demo');
+	});
+
+	it('supports React-like aliases and shorthand props', () => {
+		const state = createTestBackendState(28, 8);
+		const terminal = createTerminal(createTestBackend(state));
+
+		terminalDraw(terminal, (frame) => {
+			renderJsx(
+				frame,
+				jsxs(Column, {
+					constraints: [lengthConstraint(5), fillConstraint(1)],
+					gap: 1,
+					children: [
+						jsx(Panel, {
+							title: 'Alias',
+							p: 1,
+							children: jsx(Label, { text: 'X', fg: Color.Red, bold: true, align: 'center' }),
+						}),
+						jsxs(Row, {
+							gap: 1,
+							children: [
+								jsx(Box, { border: true, title: 'L', children: jsx(Text, { text: 'left' }) }),
+								jsx(Box, { border: true, title: 'R', children: jsx(Text, { text: 'right' }) }),
+							],
+						}),
+					],
+				}),
+			);
+		});
+
+		const output = testBackendToString(state);
+		expect(output).toContain('Alias');
+		expect(output).toContain('L');
+		expect(output).toContain('R');
+		expect(output).toContain('┌'); // Panel defaults to bordered
+
+		const xCell = findCellBySymbol(state, 'X');
+		expect(xCell?.fg).toEqual(Color.Red);
+		expect(Modifier.contains(xCell?.modifier ?? 0, Modifier.BOLD)).toBe(true);
+	});
+
+	it('has terminalDrawJsx and terminalLoopJsx helpers', () => {
+		const state = createTestBackendState(16, 3);
+		const terminal = createTerminal(createTestBackend(state));
+
+		const first = terminalDrawJsx(terminal, jsx(Text, { text: 'frame 0' }));
+		expect(first.count).toBe(0);
+		expect(testBackendToString(state)).toContain('frame 0');
+
+		const loop = terminalLoopJsx(
+			terminal,
+			(_frame, frameCount) => jsx(Text, { text: `frame ${frameCount + 1}` }),
+			{ maxFrames: 2 },
+		);
+
+		expect(loop.frames).toBe(2);
+		expect(loop.last?.count).toBe(2);
+		expect(testBackendToString(state)).toContain('frame 2');
+	});
+
+	it('throws clear runtime errors for missing required props', () => {
+		const state = createTestBackendState(10, 3);
+		const terminal = createTerminal(createTestBackend(state));
+
+		expect(() =>
+			terminalDraw(terminal, (frame) => {
+				renderJsx(frame, jsx('list', {}));
+			}),
+		).toThrow('<List> requires `items` prop.');
+
+		expect(() =>
+			terminalLoopJsx(terminal, () => jsx(Text, { text: 'no loop options' })),
+		).toThrow('terminalLoopJsx requires either `maxFrames` or `continueWhile`.');
+	});
+});

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,70 @@
+type JsxKey = string | number;
+
+type JsxProps = Record<string, unknown>;
+
+type JsxComponent<P = unknown> = (props: P) => JsxElement | null;
+
+type JsxType = string | symbol | JsxComponent<unknown>;
+
+interface JsxElement {
+	readonly type: JsxType;
+	readonly props: unknown;
+	readonly key: JsxKey | null;
+}
+
+type JsxNode =
+	| JsxElement
+	| string
+	| number
+	| boolean
+	| null
+	| undefined
+	| readonly JsxNode[];
+
+const Fragment = Symbol.for('terminui.fragment');
+
+const createJsxElement = <P>(
+	type: JsxType,
+	props: P | null | undefined,
+	key?: JsxKey,
+): JsxElement => ({
+	type,
+	props: (props ?? {}) as unknown,
+	key: key ?? null,
+});
+
+const jsx = <P>(
+	type: JsxType | JsxComponent<P>,
+	props: P | null,
+	key?: JsxKey,
+): JsxElement => createJsxElement(type as JsxType, props, key);
+
+const jsxs = jsx;
+
+const jsxDEV = <P>(
+	type: JsxType | JsxComponent<P>,
+	props: P | null,
+	key?: JsxKey,
+	_isStaticChildren?: boolean,
+	_source?: unknown,
+	_self?: unknown,
+): JsxElement => createJsxElement(type as JsxType, props, key);
+
+export namespace JSX {
+	export type Element = JsxElement;
+
+	export interface ElementChildrenAttribute {
+		children: unknown;
+	}
+
+	export interface IntrinsicAttributes {
+		key?: JsxKey;
+	}
+
+	export interface IntrinsicElements {
+		[elemName: string]: unknown;
+	}
+}
+
+export type { JsxKey, JsxProps, JsxType, JsxElement, JsxComponent, JsxNode };
+export { Fragment, jsx, jsxs, jsxDEV };

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,0 +1,758 @@
+import type { Alignment, Constraint, Margin, Rect, Spacing } from './core/layout';
+import { createLayout, createPosition, fillConstraint, splitLayout } from './core/layout';
+import type { CompletedFrame, Frame, Terminal } from './core/terminal';
+import {
+	frameRenderStatefulWidget,
+	frameRenderWidget,
+	frameSetCursorPosition,
+	terminalDraw,
+} from './core/terminal';
+import type { Style } from './core/style';
+import {
+	Modifier,
+	createStyle,
+	styleAddModifier,
+	styleBg,
+	styleFg,
+} from './core/style';
+import type { Line, Text as RichText } from './core/text';
+import type { JsxComponent, JsxElement, JsxNode, JsxProps } from './jsx-runtime';
+import { Fragment } from './jsx-runtime';
+import type { BarChartConfig, BarGroup } from './widgets/barchart';
+import { createBarChart as createBarChartWidget, renderBarChart } from './widgets/barchart';
+import type { BlockConfig, Title } from './widgets/block';
+import {
+	Borders,
+	blockBordered,
+	blockInner,
+	createBlock,
+	createPadding,
+	createTitle,
+	renderBlock,
+} from './widgets/block';
+import { renderClear } from './widgets/clear';
+import type { GaugeConfig, LineGaugeConfig } from './widgets/gauge';
+import {
+	createGauge as createGaugeWidget,
+	createLineGauge as createLineGaugeWidget,
+	gaugePercent,
+	renderGauge,
+	renderLineGauge,
+} from './widgets/gauge';
+import type { ListConfig, ListItem, ListState } from './widgets/list';
+import {
+	createList as createListWidget,
+	renderList,
+	renderStatefulList,
+} from './widgets/list';
+import type { ParagraphConfig } from './widgets/paragraph';
+import {
+	createParagraph as createParagraphWidget,
+	renderParagraph,
+} from './widgets/paragraph';
+import type { ScrollbarConfig, ScrollbarOrientation, ScrollbarState } from './widgets/scrollbar';
+import {
+	createScrollbar as createScrollbarWidget,
+	renderStatefulScrollbar,
+} from './widgets/scrollbar';
+import type { SparklineConfig } from './widgets/sparkline';
+import { createSparkline as createSparklineWidget, renderSparkline } from './widgets/sparkline';
+import type { TableCell, TableConfig, TableState, Row as TableRow } from './widgets/table';
+import {
+	createRow as createTableRowWidget,
+	createTable as createTableWidget,
+	renderStatefulTable,
+	renderTable,
+} from './widgets/table';
+import type { TabsConfig } from './widgets/tabs';
+import { createTabs as createTabsWidget, renderTabs } from './widgets/tabs';
+
+interface StackProps {
+	readonly constraints?: readonly Constraint[];
+	readonly margin?: Margin;
+	readonly spacing?: Spacing | number;
+	readonly gap?: number;
+	readonly children?: JsxNode;
+}
+
+interface StyleShorthands {
+	readonly fg?: Style['fg'];
+	readonly bg?: Style['bg'];
+	readonly bold?: boolean;
+}
+
+interface BlockShorthands {
+	readonly border?: boolean;
+	readonly title?: string | Title | readonly (string | Title)[];
+	readonly p?: number;
+	readonly px?: number;
+	readonly py?: number;
+}
+
+interface BoxProps extends Partial<BlockConfig>, StyleShorthands, BlockShorthands {
+	readonly bordered?: boolean;
+	readonly children?: JsxNode;
+}
+
+interface TextProps
+	extends Partial<Omit<ParagraphConfig, 'text'>>,
+		StyleShorthands,
+		BlockShorthands {
+	readonly text?: RichText | string;
+	readonly align?: Alignment;
+	readonly children?: JsxNode;
+}
+
+interface ListProps extends Partial<Omit<ListConfig, 'items'>>, StyleShorthands, BlockShorthands {
+	readonly items: readonly (string | ListItem)[];
+	readonly state?: ListState;
+}
+
+type TableRowInput = TableRow | readonly (string | TableCell)[];
+
+interface TableProps
+	extends Partial<Omit<TableConfig, 'rows' | 'widths' | 'header' | 'footer'>>,
+		StyleShorthands,
+		BlockShorthands {
+	readonly rows: readonly TableRowInput[];
+	readonly widths: readonly Constraint[];
+	readonly header?: TableRowInput;
+	readonly footer?: TableRowInput;
+	readonly state?: TableState;
+}
+
+interface GaugeProps extends Partial<GaugeConfig>, StyleShorthands, BlockShorthands {
+	readonly percent?: number;
+}
+
+interface LineGaugeProps extends Partial<LineGaugeConfig>, StyleShorthands, BlockShorthands {
+	readonly percent?: number;
+}
+
+interface TabsProps extends Partial<Omit<TabsConfig, 'titles'>>, StyleShorthands, BlockShorthands {
+	readonly titles: readonly (string | Line)[];
+}
+
+interface SparklineProps
+	extends Partial<Omit<SparklineConfig, 'data'>>,
+		StyleShorthands,
+		BlockShorthands {
+	readonly data: readonly number[];
+}
+
+interface BarChartProps extends Partial<Omit<BarChartConfig, 'data'>>, StyleShorthands, BlockShorthands {
+	readonly data: readonly BarGroup[];
+}
+
+interface ScrollbarProps extends Partial<Omit<ScrollbarConfig, 'orientation'>>, StyleShorthands {
+	readonly orientation: ScrollbarOrientation;
+	readonly state: ScrollbarState;
+}
+
+interface CursorProps {
+	readonly x: number;
+	readonly y: number;
+	readonly absolute?: boolean;
+}
+
+type TerminalDrawJsxRoot = JsxNode | ((frame: Frame) => JsxNode);
+
+interface TerminalLoopJsxOptions {
+	readonly maxFrames?: number;
+	readonly continueWhile?: (frameCount: number) => boolean;
+}
+
+interface TerminalLoopJsxResult {
+	readonly frames: number;
+	readonly last?: CompletedFrame;
+}
+
+const intrinsic = (type: string, props: unknown): JsxElement => ({
+	type,
+	props,
+	key: null,
+});
+
+const VStack: JsxComponent<StackProps> = (props) => intrinsic('vstack', props);
+const HStack: JsxComponent<StackProps> = (props) => intrinsic('hstack', props);
+const Column: JsxComponent<StackProps> = (props) => intrinsic('column', props);
+const Row: JsxComponent<StackProps> = (props) => intrinsic('row', props);
+const Box: JsxComponent<BoxProps> = (props) => intrinsic('box', props);
+const Panel: JsxComponent<BoxProps> = (props) => intrinsic('panel', props);
+const Text: JsxComponent<TextProps> = (props) => intrinsic('text', props);
+const Label: JsxComponent<TextProps> = (props) => intrinsic('label', props);
+const List: JsxComponent<ListProps> = (props) => intrinsic('list', props);
+const Table: JsxComponent<TableProps> = (props) => intrinsic('table', props);
+const Gauge: JsxComponent<GaugeProps> = (props) => intrinsic('gauge', props);
+const LineGauge: JsxComponent<LineGaugeProps> = (props) => intrinsic('lineGauge', props);
+const Tabs: JsxComponent<TabsProps> = (props) => intrinsic('tabs', props);
+const Sparkline: JsxComponent<SparklineProps> = (props) => intrinsic('sparkline', props);
+const BarChart: JsxComponent<BarChartProps> = (props) => intrinsic('barChart', props);
+const Scrollbar: JsxComponent<ScrollbarProps> = (props) => intrinsic('scrollbar', props);
+const Clear: JsxComponent<Record<string, never>> = (props) => intrinsic('clear', props);
+const Cursor: JsxComponent<CursorProps> = (props) => intrinsic('cursor', props);
+
+const isJsxElement = (value: unknown): value is JsxElement =>
+	typeof value === 'object' && value !== null && 'type' in value && 'props' in value;
+
+const flattenChildren = (value: JsxNode, out: JsxNode[]): void => {
+	if (value === null || value === undefined || typeof value === 'boolean') {
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const child of value) {
+			flattenChildren(child, out);
+		}
+		return;
+	}
+	out.push(value);
+};
+
+const normalizeChildren = (value: JsxNode | undefined): readonly JsxNode[] => {
+	if (value === undefined) {
+		return [];
+	}
+	const nodes: JsxNode[] = [];
+	flattenChildren(value, nodes);
+	return nodes;
+};
+
+const childrenFromProps = (props: JsxProps): readonly JsxNode[] =>
+	normalizeChildren(props.children as JsxNode | undefined);
+
+const resolveStyle = (
+	base: Style | undefined,
+	shorthands: StyleShorthands,
+): Style | undefined => {
+	let style = base ?? createStyle();
+	let changed = base !== undefined;
+
+	if (shorthands.fg !== undefined) {
+		style = styleFg(style, shorthands.fg);
+		changed = true;
+	}
+	if (shorthands.bg !== undefined) {
+		style = styleBg(style, shorthands.bg);
+		changed = true;
+	}
+	if (shorthands.bold) {
+		style = styleAddModifier(style, Modifier.BOLD);
+		changed = true;
+	}
+
+	return changed ? style : undefined;
+};
+
+const resolvePaddingShorthand = (p: number | undefined, px: number | undefined, py: number | undefined) => {
+	if (p === undefined && px === undefined && py === undefined) {
+		return undefined;
+	}
+	const vertical = py ?? p ?? 0;
+	const horizontal = px ?? p ?? 0;
+	return createPadding(vertical, horizontal, vertical, horizontal);
+};
+
+const resolveBlock = (
+	block: BlockConfig | undefined,
+	shorthands: BlockShorthands,
+): BlockConfig | undefined => {
+	const resolvedTitles = resolveTitles(shorthands.title);
+	const resolvedPadding = resolvePaddingShorthand(shorthands.p, shorthands.px, shorthands.py);
+
+	const needsBlock =
+		block !== undefined ||
+		shorthands.border !== undefined ||
+		resolvedTitles !== undefined ||
+		resolvedPadding !== undefined;
+
+	if (!needsBlock) {
+		return undefined;
+	}
+
+	const overrides: Partial<BlockConfig> = {
+		...(block ?? {}),
+		...(resolvedTitles !== undefined ? { titles: resolvedTitles } : {}),
+		...(resolvedPadding !== undefined ? { padding: resolvedPadding } : {}),
+	};
+
+	if (shorthands.border === true) {
+		return blockBordered(overrides);
+	}
+	if (shorthands.border === false) {
+		return createBlock({ ...overrides, borders: Borders.NONE });
+	}
+	return createBlock(overrides);
+};
+
+const requiredProp = <T>(
+	value: T | undefined,
+	component: string,
+	prop: string,
+): T => {
+	if (value !== undefined) {
+		return value;
+	}
+	throw new Error(`<${component}> requires \`${prop}\` prop.`);
+};
+
+const renderChildren = (frame: Frame, children: readonly JsxNode[], area: Rect): void => {
+	for (const child of children) {
+		renderNode(frame, child, area);
+	}
+};
+
+const renderPrimitive = (frame: Frame, value: string | number, area: Rect): void => {
+	const paragraph = createParagraphWidget(String(value));
+	frameRenderWidget(frame, renderParagraph(paragraph), area);
+};
+
+const resolveSpacing = (
+	spacing: StackProps['spacing'],
+	gap: StackProps['gap'],
+): Spacing | undefined => {
+	if (spacing === undefined) {
+		if (gap === undefined) {
+			return undefined;
+		}
+		return { type: 'space', value: gap };
+	}
+	if (typeof spacing === 'number') {
+		return { type: 'space', value: spacing };
+	}
+	return spacing;
+};
+
+const renderStack = (
+	frame: Frame,
+	direction: 'horizontal' | 'vertical',
+	props: StackProps,
+	area: Rect,
+): void => {
+	const children = normalizeChildren(props.children);
+	if (children.length === 0) {
+		return;
+	}
+
+	const constraints: Constraint[] = [];
+	for (let i = 0; i < children.length; i++) {
+		constraints.push(props.constraints?.[i] ?? fillConstraint(1));
+	}
+
+	const layout = createLayout(constraints, {
+		direction,
+		margin: props.margin,
+		spacing: resolveSpacing(props.spacing, props.gap),
+	});
+
+	const chunks = splitLayout(layout, area);
+	const count = Math.min(chunks.length, children.length);
+
+	for (let i = 0; i < count; i++) {
+		const chunk = chunks[i];
+		const child = children[i];
+		if (chunk === undefined || child === undefined) {
+			continue;
+		}
+		renderNode(frame, child, chunk);
+	}
+};
+
+const toTitle = (value: string | Title): Title =>
+	typeof value === 'string' ? createTitle(value) : value;
+
+const resolveTitles = (title: BoxProps['title']): readonly Title[] | undefined => {
+	if (title === undefined) {
+		return undefined;
+	}
+	if (Array.isArray(title)) {
+		return title.map(toTitle);
+	}
+	return [toTitle(title as string | Title)];
+};
+
+const renderBox = (frame: Frame, props: BoxProps, area: Rect): void => {
+	const { bordered, border, title, p, px, py, fg, bg, bold, children, ...rest } = props;
+	const resolvedTitles = rest.titles ?? resolveTitles(title);
+	const resolvedPadding = rest.padding ?? resolvePaddingShorthand(p, px, py);
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const blockOverrides: Partial<BlockConfig> = {
+		...rest,
+		...(resolvedTitles !== undefined ? { titles: resolvedTitles } : {}),
+		...(resolvedPadding !== undefined ? { padding: resolvedPadding } : {}),
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+	};
+
+	const resolvedBorder = border ?? bordered;
+	const block = resolvedBorder === true
+		? blockBordered(blockOverrides)
+		: resolvedBorder === false
+		? createBlock({ ...blockOverrides, borders: Borders.NONE })
+		: createBlock(blockOverrides);
+
+	frameRenderWidget(frame, renderBlock(block), area);
+
+	const inner = blockInner(block, area);
+	if (inner.width === 0 || inner.height === 0) {
+		return;
+	}
+
+	renderChildren(frame, normalizeChildren(children), inner);
+};
+
+const extractTextChildren = (children: readonly JsxNode[]): string => {
+	let result = '';
+	for (const child of children) {
+		if (typeof child === 'string' || typeof child === 'number') {
+			result += String(child);
+		}
+	}
+	return result;
+};
+
+const renderText = (frame: Frame, props: TextProps, area: Rect): void => {
+	const { text, align, fg, bg, bold, border, title, p, px, py, children, ...rest } = props;
+	const resolvedText = text ?? extractTextChildren(normalizeChildren(children));
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const paragraph = createParagraphWidget(resolvedText, {
+		...rest,
+		...(align !== undefined ? { alignment: align } : {}),
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	});
+	frameRenderWidget(frame, renderParagraph(paragraph), area);
+};
+
+const renderListNode = (frame: Frame, props: ListProps, area: Rect): void => {
+	const { items, state, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const list = createListWidget(requiredProp(items, 'List', 'items'), {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	});
+
+	if (state !== undefined) {
+		frameRenderStatefulWidget(frame, renderStatefulList(list), area, state);
+		return;
+	}
+
+	frameRenderWidget(frame, renderList(list), area);
+};
+
+const isTableRow = (value: TableRowInput): value is TableRow =>
+	typeof value === 'object' && value !== null && 'cells' in value;
+
+const toTableRow = (value: TableRowInput): TableRow =>
+	isTableRow(value) ? value : createTableRowWidget(value);
+
+const renderTableNode = (frame: Frame, props: TableProps, area: Rect): void => {
+	const { rows, widths, header, footer, state, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const tableRows = requiredProp(rows, 'Table', 'rows').map(toTableRow);
+	const resolvedWidths = requiredProp(widths, 'Table', 'widths');
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const table = createTableWidget(tableRows, resolvedWidths, {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+		...(header !== undefined ? { header: toTableRow(header) } : {}),
+		...(footer !== undefined ? { footer: toTableRow(footer) } : {}),
+	});
+
+	if (state !== undefined) {
+		frameRenderStatefulWidget(frame, renderStatefulTable(table), area, state);
+		return;
+	}
+
+	frameRenderWidget(frame, renderTable(table), area);
+};
+
+const renderGaugeNode = (frame: Frame, props: GaugeProps, area: Rect): void => {
+	const { percent, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const config = {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	};
+	if (percent !== undefined) {
+		const gauge = gaugePercent(percent, config);
+		frameRenderWidget(frame, renderGauge(gauge), area);
+		return;
+	}
+
+	const gauge = createGaugeWidget(config);
+	frameRenderWidget(frame, renderGauge(gauge), area);
+};
+
+const renderLineGaugeNode = (frame: Frame, props: LineGaugeProps, area: Rect): void => {
+	const { percent, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const config = {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	};
+	if (percent !== undefined) {
+		const lineGauge = createLineGaugeWidget({ ...config, ratio: percent / 100 });
+		frameRenderWidget(frame, renderLineGauge(lineGauge), area);
+		return;
+	}
+
+	const lineGauge = createLineGaugeWidget(config);
+	frameRenderWidget(frame, renderLineGauge(lineGauge), area);
+};
+
+const renderTabsNode = (frame: Frame, props: TabsProps, area: Rect): void => {
+	const { titles, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const tabs = createTabsWidget(requiredProp(titles, 'Tabs', 'titles'), {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	});
+	frameRenderWidget(frame, renderTabs(tabs), area);
+};
+
+const renderSparklineNode = (frame: Frame, props: SparklineProps, area: Rect): void => {
+	const { data, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const sparkline = createSparklineWidget(requiredProp(data, 'Sparkline', 'data'), {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	});
+	frameRenderWidget(frame, renderSparkline(sparkline), area);
+};
+
+const renderBarChartNode = (frame: Frame, props: BarChartProps, area: Rect): void => {
+	const { data, fg, bg, bold, border, title, p, px, py, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const resolvedBlock = resolveBlock(rest.block, { border, title, p, px, py });
+	const chart = createBarChartWidget(requiredProp(data, 'BarChart', 'data'), {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+		...(resolvedBlock !== undefined ? { block: resolvedBlock } : {}),
+	});
+	frameRenderWidget(frame, renderBarChart(chart), area);
+};
+
+const renderScrollbarNode = (frame: Frame, props: ScrollbarProps, area: Rect): void => {
+	const { orientation, state, fg, bg, bold, ...rest } = props;
+	const resolvedStyle = resolveStyle(rest.style, { fg, bg, bold });
+	const scrollbar = createScrollbarWidget(requiredProp(orientation, 'Scrollbar', 'orientation'), {
+		...rest,
+		...(resolvedStyle !== undefined ? { style: resolvedStyle } : {}),
+	});
+	frameRenderStatefulWidget(
+		frame,
+		renderStatefulScrollbar(scrollbar),
+		area,
+		requiredProp(state, 'Scrollbar', 'state'),
+	);
+};
+
+const renderCursorNode = (frame: Frame, props: CursorProps, area: Rect): void => {
+	const x = requiredProp(props.x, 'Cursor', 'x');
+	const y = requiredProp(props.y, 'Cursor', 'y');
+	if (props.absolute) {
+		frameSetCursorPosition(frame, createPosition(x, y));
+		return;
+	}
+	frameSetCursorPosition(frame, createPosition(area.x + x, area.y + y));
+};
+
+const renderIntrinsic = (frame: Frame, type: string, props: JsxProps, area: Rect): void => {
+	switch (type) {
+		case 'vstack':
+		case 'column':
+			renderStack(frame, 'vertical', props as unknown as StackProps, area);
+			return;
+		case 'hstack':
+		case 'row':
+			renderStack(frame, 'horizontal', props as unknown as StackProps, area);
+			return;
+		case 'box':
+			renderBox(frame, props as unknown as BoxProps, area);
+			return;
+		case 'panel': {
+			const panelProps = props as unknown as BoxProps;
+			renderBox(
+				frame,
+				{ ...panelProps, bordered: panelProps.bordered ?? panelProps.border ?? true },
+				area,
+			);
+			return;
+		}
+		case 'text':
+		case 'label':
+			renderText(frame, props as unknown as TextProps, area);
+			return;
+		case 'list':
+			renderListNode(frame, props as unknown as ListProps, area);
+			return;
+		case 'table':
+			renderTableNode(frame, props as unknown as TableProps, area);
+			return;
+		case 'gauge':
+			renderGaugeNode(frame, props as unknown as GaugeProps, area);
+			return;
+		case 'lineGauge':
+			renderLineGaugeNode(frame, props as unknown as LineGaugeProps, area);
+			return;
+		case 'tabs':
+			renderTabsNode(frame, props as unknown as TabsProps, area);
+			return;
+		case 'sparkline':
+			renderSparklineNode(frame, props as unknown as SparklineProps, area);
+			return;
+		case 'barChart':
+			renderBarChartNode(frame, props as unknown as BarChartProps, area);
+			return;
+		case 'scrollbar':
+			renderScrollbarNode(frame, props as unknown as ScrollbarProps, area);
+			return;
+		case 'clear':
+			frameRenderWidget(frame, renderClear(), area);
+			return;
+		case 'cursor':
+			renderCursorNode(frame, props as unknown as CursorProps, area);
+			return;
+		default:
+			renderChildren(frame, childrenFromProps(props), area);
+	}
+};
+
+const renderNode = (frame: Frame, node: JsxNode, area: Rect): void => {
+	if (node === null || node === undefined || typeof node === 'boolean') {
+		return;
+	}
+
+	if (typeof node === 'string' || typeof node === 'number') {
+		renderPrimitive(frame, node, area);
+		return;
+	}
+
+	if (Array.isArray(node)) {
+		renderChildren(frame, node, area);
+		return;
+	}
+
+	if (!isJsxElement(node)) {
+		return;
+	}
+
+	if (node.type === Fragment) {
+		renderChildren(frame, childrenFromProps(node.props as JsxProps), area);
+		return;
+	}
+
+	if (typeof node.type === 'function') {
+		renderNode(frame, node.type(node.props), area);
+		return;
+	}
+
+	if (typeof node.type === 'string') {
+		renderIntrinsic(frame, node.type, node.props as JsxProps, area);
+	}
+};
+
+const renderJsx = (frame: Frame, root: JsxNode, area: Rect = frame.area): void => {
+	renderNode(frame, root, area);
+};
+
+const terminalDrawJsx = (
+	terminal: Terminal,
+	root: TerminalDrawJsxRoot,
+	area?: Rect,
+): CompletedFrame =>
+	terminalDraw(terminal, (frame) => {
+		const resolvedRoot = typeof root === 'function' ? root(frame) : root;
+		renderJsx(frame, resolvedRoot, area ?? frame.area);
+	});
+
+const terminalLoopJsx = (
+	terminal: Terminal,
+	render: (frame: Frame, frameCount: number) => JsxNode,
+	options?: TerminalLoopJsxOptions,
+): TerminalLoopJsxResult => {
+	const maxFrames = options?.maxFrames;
+	const continueWhile = options?.continueWhile;
+
+	if (maxFrames === undefined && continueWhile === undefined) {
+		throw new Error('terminalLoopJsx requires either `maxFrames` or `continueWhile`.');
+	}
+
+	let frameCount = 0;
+	let last: CompletedFrame | undefined;
+
+	while (true) {
+		if (maxFrames !== undefined && frameCount >= maxFrames) {
+			break;
+		}
+		if (continueWhile !== undefined && !continueWhile(frameCount)) {
+			break;
+		}
+		last = terminalDrawJsx(terminal, (frame) => render(frame, frameCount));
+		frameCount++;
+	}
+
+	return {
+		frames: frameCount,
+		...(last !== undefined ? { last } : {}),
+	};
+};
+
+const renderUI = renderJsx;
+
+export type {
+	StackProps,
+	StyleShorthands,
+	BlockShorthands,
+	BoxProps,
+	TextProps,
+	ListProps,
+	TableProps,
+	GaugeProps,
+	LineGaugeProps,
+	TabsProps,
+	SparklineProps,
+	BarChartProps,
+	ScrollbarProps,
+	CursorProps,
+	TerminalDrawJsxRoot,
+	TerminalLoopJsxOptions,
+	TerminalLoopJsxResult,
+};
+
+export {
+	Fragment,
+	renderJsx,
+	renderUI,
+	terminalDrawJsx,
+	terminalLoopJsx,
+	VStack,
+	HStack,
+	Column,
+	Row,
+	Box,
+	Panel,
+	Text,
+	Label,
+	List,
+	Table,
+	Gauge,
+	LineGauge,
+	Tabs,
+	Sparkline,
+	BarChart,
+	Scrollbar,
+	Clear,
+	Cursor,
+};

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-	entry: ['src/index.ts'],
+	entry: ['src/index.ts', 'src/jsx.ts', 'src/jsx-runtime.ts'],
 	format: ['esm'],
 	dts: true,
 	splitting: false,


### PR DESCRIPTION
## Summary
- add a React-like JSX runtime and JSX component API for terminal UI composition
- add JSX examples (`jsx-hello`, `jsx-dashboard`, `jsx-chatbot`)
- polish `jsx-chatbot` with alternate-screen loop, simplified modern CLI aesthetics, reliable input handling, and arrow-key chat scrolling
- document chatbot usage/controls in README
- bump changelog to minor release `0.3.0`

## Test plan
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm build